### PR TITLE
Make a copy of Options for each new session

### DIFF
--- a/pgstore.go
+++ b/pgstore.go
@@ -74,7 +74,8 @@ func (db *PGStore) New(r *http.Request, name string) (*sessions.Session, error) 
 	if session == nil {
 		return session, nil
 	}
-	session.Options = &(*db.Options)
+	opts := *db.Options
+	session.Options = &(opts)
 	session.IsNew = true
 
 	var err error


### PR DESCRIPTION
In the current implementation changing options on an individual session will change it for the store as well. In my application I set the default store options once on boot up and expect them to be used except for the sessions where I change them.