### PR TITLE
Collapse underline in db column names

### DIFF
--- a/pgstore.go
+++ b/pgstore.go
@@ -26,9 +26,9 @@ type Session struct {
 	Id         int64     `db:"id"`
 	Key        string    `db:"key"`
 	Data       string    `db:"data"`
-	CreatedOn  time.Time `db:"created_on"`
-	ModifiedOn time.Time `db:"modified_on"`
-	ExpiresOn  time.Time `db:"expires_on"`
+	CreatedOn  time.Time `db:"createdon"`
+	ModifiedOn time.Time `db:"modifiedon"`
+	ExpiresOn  time.Time `db:"expireson"`
 }
 
 // NewPGStore creates a new PGStore instance


### PR DESCRIPTION
This removes the underline in the database column names because it looks like
they are already doing that in Gorp and this makes sure that they are never
there.

In some cases this can confuse a user and make the some strange things happen.

This is one step in adding Travis-CI to the repo.

Thanks!