### PR TITLE
Add underscores when querying column names

### DIFF
--- a/cleanup.go
+++ b/cleanup.go
@@ -53,6 +53,6 @@ func (db *PGStore) cleanup(interval time.Duration, quit <-chan struct{}, done ch
 
 // deleteExpired deletes expired sessions from the database.
 func (db *PGStore) deleteExpired() error {
-	_, err := db.DbMap.Exec("DELETE FROM http_sessions WHERE expireson < now()")
+	_, err := db.DbMap.Exec("DELETE FROM http_sessions WHERE expires_on < now()")
 	return err
 }

--- a/cleanup_test.go
+++ b/cleanup_test.go
@@ -40,7 +40,7 @@ func TestCleanup(t *testing.T) {
 
 	// SELECT expired sessions. We should get a zero-length result slice back.
 	var results []int64
-	_, err = ss.DbMap.Select(&results, "SELECT id FROM http_sessions WHERE expireson < now()")
+	_, err = ss.DbMap.Select(&results, "SELECT id FROM http_sessions WHERE expires_on < now()")
 	if err != nil {
 		t.Fatalf("failed to select expired sessions from DB: %v", err)
 	}

--- a/pgstore.go
+++ b/pgstore.go
@@ -218,7 +218,7 @@ func (db *PGStore) save(session *sessions.Session) error {
 	if session.IsNew {
 		err = db.DbMap.Insert(&s)
 	} else {
-		_, err = db.DbMap.Exec("update http_sessions set data=$1, modifiedon=$2, expireson=$3 where key=$4", s.Data, s.ModifiedOn, s.ExpiresOn, s.Key)
+		_, err = db.DbMap.Exec("update http_sessions set data=$1, modified_on=$2, expires_on=$3 where key=$4", s.Data, s.ModifiedOn, s.ExpiresOn, s.Key)
 	}
 
 	return err


### PR DESCRIPTION
This commit aims to fix tests which fails on not finding columns such as
`expireson`. Adding the underscore that are used when creating the table
should fix this.

An issue with this is that it must have worked previously without underscores.
In that case this might break existing usage.

From the simple tests I have made this should work. Unfortunately I don't have
access to an older database where not using underscores might have worked.

This will address the issues in #11 

/cc @caarlos0 @elithrar 

Thanks!