### PR TITLE
NewPGStore should not ignore errors

### DIFF
--- a/cleanup_test.go
+++ b/cleanup_test.go
@@ -8,7 +8,12 @@ import (
 )
 
 func TestCleanup(t *testing.T) {
-	ss := NewPGStore(os.Getenv("PGSTORE_TEST_CONN"), []byte(secret))
+	ss, err := NewPGStore(os.Getenv("PGSTORE_TEST_CONN"), []byte(secret))
+
+	if err != nil {
+		t.Fatal("Failed to get store", err)
+	}
+
 	if ss == nil {
 		t.Skip("This test requires a real database")
 	}

--- a/pgstore.go
+++ b/pgstore.go
@@ -33,11 +33,11 @@ type Session struct {
 
 // NewPGStore creates a new PGStore instance and a new database/sql pool.
 // This will also create in the database the schema needed by pgstore.
-func NewPGStore(dbURL string, keyPairs ...[]byte) *PGStore {
+func NewPGStore(dbURL string, keyPairs ...[]byte) (*PGStore, error) {
 	db, err := sql.Open("postgres", dbURL)
 	if err != nil {
 		// Ignore and return nil
-		return nil
+		return nil, err
 	}
 	return NewPGStoreFromPool(db, keyPairs...)
 }
@@ -45,7 +45,7 @@ func NewPGStore(dbURL string, keyPairs ...[]byte) *PGStore {
 // NewPGStoreFromPool creates a new PGStore instance from an existing
 // database/sql pool.
 // This will also create in the database the schema needed by pgstore.
-func NewPGStoreFromPool(db *sql.DB, keyPairs ...[]byte) *PGStore {
+func NewPGStoreFromPool(db *sql.DB, keyPairs ...[]byte) (*PGStore, error) {
 	dbmap := &gorp.DbMap{Db: db, Dialect: gorp.PostgresDialect{}}
 
 	dbStore := &PGStore{
@@ -63,10 +63,10 @@ func NewPGStoreFromPool(db *sql.DB, keyPairs ...[]byte) *PGStore {
 
 	if err != nil {
 		// Ignore and return nil
-		return nil
+		return nil, err
 	}
 
-	return dbStore
+	return dbStore, nil
 }
 
 // Close closes the database connection

--- a/pgstore_test.go
+++ b/pgstore_test.go
@@ -27,7 +27,11 @@ func (ho headerOnlyResponseWriter) WriteHeader(int) {
 var secret = "EyaC2BPcJtNqU3tjEHy+c+Wmqc1yihYIbUWEl/jk0Ga73kWBclmuSFd9HuJKwJw/Wdsh1XnjY2Bw1HBVph6WOw=="
 
 func TestPGStore(t *testing.T) {
-	ss := NewPGStore(os.Getenv("PGSTORE_TEST_CONN"), []byte(secret))
+	ss, err := NewPGStore(os.Getenv("PGSTORE_TEST_CONN"), []byte(secret))
+
+	if err != nil {
+		t.Fatal("failed to get store", err.Error())
+	}
 
 	if ss == nil {
 		t.Skip("This test requires a real database")
@@ -121,7 +125,11 @@ func TestPGStore(t *testing.T) {
 }
 
 func TestSessionOptionsAreUniquePerSession(t *testing.T) {
-	ss := NewPGStore(os.Getenv("PGSTORE_TEST_CONN"), []byte(secret))
+	ss, err := NewPGStore(os.Getenv("PGSTORE_TEST_CONN"), []byte(secret))
+
+	if err != nil {
+		t.Fatal("Failed to get store", err)
+	}
 
 	if ss == nil {
 		t.Skip("This test requires a real database")


### PR DESCRIPTION
Hi,

ignoring errors is bad, complicates debugging for those who use the package. I modified the NewPGStore (and Pool version) to return the error in standard Golang fashion (value, error).

Cheers
Marin