### PR TITLE
Fix issues with linter and drop 1.5 CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.5
   - 1.6
+  - 1.7
   - tip
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ check:
 .PHONY: metalint
 metalint:
 	which gometalinter > /dev/null || (go get github.com/alecthomas/gometalinter && gometalinter --install --update)
-	gometalinter --cyclo-over=20 -e "struct field Id should be ID" --enable="gofmt -s" --enable=misspell --fast ./...
+	gometalinter --cyclo-over=20 -e "struct field Id should be ID" --disable=gas --enable=misspell --fast ./...
 
 .PHONY: fmt
 fmt:


### PR DESCRIPTION
This an issue that the linter `gofmt -s` isn't found and will fail the build.
Also, the CI tests for Go 1.5 is now dropped.