### PR TITLE
Switch to golangci-lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: go
 
 go:
-  - 1.6
-  - 1.7
   - tip
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,10 @@ go:
 install:
   - make get-deps
   - go get github.com/campoy/embedmd
+  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.6
 
 script:
-  - make metalint
+  - make lint-check
   - make docs-check
   - make check
 

--- a/Makefile
+++ b/Makefile
@@ -16,16 +16,15 @@ get-deps:
 	go get -v ./...
 
 .PHONY: test
-test: get-deps metalint docs-check check
+test: get-deps lint-check docs-check check
 
 .PHONY: check
 check:
 	go test -v -race -cover ./...
 
-.PHONY: metalint
-metalint:
-	which gometalinter > /dev/null || (go get github.com/alecthomas/gometalinter && gometalinter --install --update)
-	gometalinter --cyclo-over=20 -e "struct field Id should be ID" --disable=gas --enable=misspell --fast ./...
+.PHONY: lint-check
+lint-check:
+	golangci-lint run
 
 .PHONY: fmt
 fmt:

--- a/pgstore_test.go
+++ b/pgstore_test.go
@@ -112,6 +112,10 @@ func TestPGStore(t *testing.T) {
 
 	req.AddCookie(sessions.NewCookie(session.Name(), encoded, session.Options))
 	session, err = ss.New(req, "my session")
+	if err != nil {
+		t.Fatal("failed to create session", err)
+	}
+
 	session.Values["big"] = make([]byte, base64.StdEncoding.DecodedLen(4096*2))
 
 	if err = ss.Save(req, headerOnlyResponseWriter(m), session); err == nil {


### PR DESCRIPTION
This switches to golangci-lint since gometalinter has been deprecated.
The commit also adds an err-check in pgstore_test.go.

Thanks!